### PR TITLE
Address Buffer constructor deprecation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,12 @@
 sudo: false
 language: node_js
 node_js:
-  - "0.11"
-  - "0.12"
-  - "4"
   - "5"
+  - "8"
+  - "10"
 matrix:
   include:
-    - node_js: "4"
+    - node_js: "10"
       env: TEST_SUITE=lint
 env:
   - TEST_SUITE=unit

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "unit": "tape test/*.js"
   },
   "dependencies": {
-    "bn.js": "^5.0.0",
+    "bn.js": "^5.1.1",
     "randombytes": "^2.0.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "unit": "tape test/*.js"
   },
   "dependencies": {
-    "bn.js": "^4.11.0",
+    "bn.js": "^5.0.0",
     "randombytes": "^2.0.1"
   },
   "devDependencies": {

--- a/test/index.js
+++ b/test/index.js
@@ -6,7 +6,7 @@ var tape = require('tape')
 var crt = require('../')
 
 require('./fixtures').forEach(function (fixture, i) {
-  var key = new Buffer(fixture, 'hex')
+  var key = Buffer.from(fixture, 'hex')
   var priv = parseKey(key)
 
   for (var j1 = 1; j1 < 31; ++j1) {
@@ -26,7 +26,7 @@ require('./fixtures').forEach(function (fixture, i) {
       } while (r.cmp(priv.modulus) >= 0)
       var buf = r.toArrayLike(Buffer, 'be')
       if (buf.byteLength < priv.modulus.byteLength()) {
-        var tmp = new Buffer(priv.modulus.byteLength() - buf.byteLength)
+        var tmp = Buffer.alloc(priv.modulus.byteLength() - buf.byteLength)
         tmp.fill(0)
         buf = Buffer.concat([tmp, buf])
       }


### PR DESCRIPTION
This requires to drop legacy (priort to 5) node.js which does not have
Buffer.alloc/Buffer.from added in Node.js 5.10.