### PR TITLE
bump bn.js to 5.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "unit": "tape test/*.js"
   },
   "dependencies": {
-    "bn.js": "^4.11.0",
+    "bn.js": "^5.0.0",
     "randombytes": "^2.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
https://github.com/indutny/elliptic/issues/191 (`browserify-rsa` need bump to 4.1.0)