### PR TITLE
Upgrading node versions and Adding ppc64le architecture support on tr…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,30 @@
 sudo: false
 language: node_js
 node_js:
-  - "0.11"
-  - "0.12"
   - "4"
   - "5"
+  - "6"
+  - "7"
+  - "8"
+  - "9"
+  - "10"
 matrix:
   include:
     - node_js: "4"
       env: TEST_SUITE=lint
+    - node_js: "5"
+      arch: ppc64le
+    - node_js: "6"
+      arch: ppc64le
+    - node_js: "7"
+      arch: ppc64le
+    - node_js: "8"
+      arch: ppc64le
+    - node_js: "9"
+      arch: ppc64le
+    - node_js: "10"
+      arch: ppc64le
+
 env:
   - TEST_SUITE=unit
 script: npm run-script $TEST_SUITE


### PR DESCRIPTION
…avis-ciHi,
I had added ppc64le(Linux on Power) architecture support on travis-ci in the PR and looks like its been successfully added. I believe it is ready for the final review and merge. The travis ci build logs can be verified from the link below.
https://www.travis-ci.com/github/kishorkunal-raj/browserify-rsa/builds/209632523

Reason behind running tests on ppc64le: This package is included in the ppc64le versions of RHEL and Ubuntu - this allows the top of tree to be tested continuously as it is for Intel, making it easier to catch any possible regressions on ppc64le before the distros begin their clones and builds. This reduces the work in integrating this package into future versions of RHEL/Ubuntu.

Please have a look.

Regards,
Kishor Kunal Raj