### PR TITLE
Add require on safe-buffer dependency to fix Buffer undefined error when ran in a browser.

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@
 
 var BN = require('bn.js');
 var randomBytes = require('randombytes');
+var Buffer = require('safe-buffer').Buffer;
 
 function getr(priv) {
 	var len = priv.modulus.byteLength();

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
 	},
 	"dependencies": {
 		"bn.js": "^5.2.1",
-		"randombytes": "^2.1.0"
+		"randombytes": "^2.1.0",
+		"safe-buffer": "^5.2.1"
 	},
 	"devDependencies": {
 		"@ljharb/eslint-config": "^21.1.1",

--- a/test/index.js
+++ b/test/index.js
@@ -4,7 +4,9 @@ var crypto = require('crypto');
 var constants = require('constants');
 var parseKey = require('parse-asn1');
 var BN = require('bn.js');
+var Buffer = require('safe-buffer').Buffer;
 var test = require('tape');
+
 var crt = require('../');
 
 var fixtures = require('./fixtures');


### PR DESCRIPTION
This change makes browserify-rsa run in a browser, clientside, which is mainly the purpose of having a browserify module.
browserify-rsa depends on Buffer, which is part of Node js API, only available serverside and therefore not available when running in the browser.
This can be fixed by adding 'safe-buffer' as dependency and following require statement.

`var Buffer = require('safe-buffer').Buffer`

This was added to the index.js script, in the same way as allready set in browserify-aes and others.